### PR TITLE
Fixed filename mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ To extract and run the application in Code::Blocks <br/>
 $ mkdir *MyDir* <br/>
 $ cd *MyDir* <br/>
 $ wget https://github.com/Qengineering/Face-Recognition-Jetson-Nano/archive/refs/heads/main.zip <br/>
-$ unzip -j master.zip <br/>
-Remove master.zip and README.md as they are no longer needed. <br/> 
-$ rm master.zip <br/>
+$ unzip -j main.zip <br/>
+Remove main.zip and README.md as they are no longer needed. <br/> 
+$ rm main.zip <br/>
 $ rm README.md <br/> <br/>
 Your *MyDir* folder must now look like this: <br/> 
 Graham Norton.jpg (example image)<br/>


### PR DESCRIPTION
Fixed documentation error by replacing master.zip with main.zip in README.md 